### PR TITLE
Update serve.js to use port from env if it exists

### DIFF
--- a/serve.js
+++ b/serve.js
@@ -2,7 +2,7 @@ var http = require('http')
 var serve = require('ecstatic')
 var open = require('opener')
 
-var PORT = 3001
+var PORT = process.env.PORT || 3001
 
 exports.init = function() {
   http.createServer(


### PR DESCRIPTION
This makes it possible to deploy Decent via Dokku (http://dokku.viewdocs.io/dokku/) with a git push. (Should also make it work anywhere buildpacks are used.)

(Note: I also had to commit my build folder for the deployment to work correctly as the build task is currently not run on buildpack deployments.)

You can see it running at https://ind.ie/labs/decent (currently does nothing as the pub as no peers).